### PR TITLE
Don't do HTML formatting when exporting a TSV

### DIFF
--- a/html/Callbacks/PriorityAsString/Elements/RT__Ticket/ColumnMap/Once
+++ b/html/Callbacks/PriorityAsString/Elements/RT__Ticket/ColumnMap/Once
@@ -6,6 +6,11 @@ my $printer = sub {
     my ($class, $string) = @_;
     return '' unless defined $string && length $string;
 
+    my $request_path = $HTML::Mason::Commands::r->path_info;
+    if ($request_path =~ /Results\.tsv/) {
+        return $string;
+    }
+
     my $escaped = $m->interp->apply_escapes($string, 'h');
     my $loc_escaped = $m->interp->apply_escapes(loc($string), 'h');
     return \( qq{<span class="ticket-info-$class-}. lc($escaped) .qq{">$loc_escaped</span>} );


### PR DESCRIPTION
This patch avoids applying HTML formatting when the priority name is printed as part of a TSV export.
